### PR TITLE
change separator to print errors for a smaller one

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1806,7 +1806,7 @@ let print_error_context fmt = function
   | [x] ->
     Printf.fprintf fmt "Cannot find %s" x
   | x::rest ->
-    let sep = " while looking for " in
+    let sep = " > " in
     Printf.fprintf fmt "Cannot find %s%a" x
       (List.print ~first:sep ~last:"" ~sep String.print) rest
 


### PR DESCRIPTION
This change permits to have less noise in error messages.

Ex:

Parse error: Error at line 9, col 14 (near 'a'): Cannot find "{" while looking for units while looking for function
while looking for arithmetic operator while looking for bitwise logical operator while looking for arithmetic operator
while looking for arithmetic operator while looking for comparison operator while looking for conditional expression
while looking for logical AND operator while looking for logical OR operator while looking for selected field
while looking for repeating while looking for select clause while looking for repeating while looking for operation
while looking for named function while looking for repeating while looking for program

Parse error: Error at line 9, col 14 (near 'a'): Cannot find "{" > units > function > arithmetic operator >
bitwise logical operator > arithmetic operator > arithmetic operator > comparison operator > conditional expression >
logical AND operator > logical OR operator > selected field > repeating > select clause > repeating > operation >
named function > repeating > program